### PR TITLE
Segfault fix

### DIFF
--- a/src/kafka-consumer.h
+++ b/src/kafka-consumer.h
@@ -94,7 +94,9 @@ class KafkaConsumer : public Connection {
   QueueCallbacks::QueueDispatcher queue_dispatcher;
   std::map<std::string, QueueCallbacks::QueueEventCallbackOpaque *> queue_dispatcher_opaques;
 
-
+  /**
+   * @locality internal librdkafka thread
+   */
   static void foreign_thread_queue_event_cb(rd_kafka_t *rk_p, void *opaque) {
     QueueCallbacks::QueueEventCallbackOpaque *qe = static_cast<QueueCallbacks::QueueEventCallbackOpaque*>(opaque);
     qe->dispatcher->Add(qe->key);

--- a/src/queue-callback.cc
+++ b/src/queue-callback.cc
@@ -41,7 +41,7 @@ QueueDispatcher::~QueueDispatcher() {
 void QueueDispatcher::Activate() {
   scoped_mutex_lock lock(async_lock);
   if (!async) {
-    async = new uv_async_t();
+    async = new uv_async_t;
     uv_async_init(uv_default_loop(), async, AsyncMessage_);
 
     async->data = this;

--- a/src/queue-callback.h
+++ b/src/queue-callback.h
@@ -46,6 +46,7 @@ class QueueDispatcher {
   std::vector<std::string> events;
 
   uv_mutex_t async_lock;
+  uv_mutex_t event_lock;
 
  private:
   NAN_INLINE static NAUV_WORK_CB(AsyncMessage_) {


### PR DESCRIPTION
to address https://github.com/withthegrid/teleport/issues/2670.

These are two traces of the segfaults that we have. They are both logged in the application gateway. 

First case:
```
-----[ Native Stacktraces ]-----
=========== Caught a Segmentation Fault [pid=1] ===========
[pc=0x00007fec4c46f68e, sp=0x00007fec3cbf7d60] in segfault_handler(int)+0x4e
[pc=0x00007fec74b4c050, sp=0x00007fec3cbf7d80] in __sigaction+0x40
[pc=0x0000000001d2bdc0, sp=0x00007fec3cbf8a78] in uv_async_send+0x0
[pc=0x00007fec4d5ea7e6, sp=0x00007fec3cbf8a80] in rd_kafka_q_enq1.constprop.0.isra.0+0x166
[pc=0x00007fec4d5f1064, sp=0x00007fec3cbf8ab0] in rd_kafka_toppar_fetch_stop+0x44
[pc=0x00007fec4d56bb0d, sp=0x00007fec3cbf8c60] in rd_kafka_thread_main+0x1fd
[pc=0x00007fec4d59c7a4, sp=0x00007fec3cbf8b30] in rd_kafka_q_serve.localalias+0x324
[pc=0x00007fec4d5f2e83, sp=0x00007fec3cbf8ae0] in rd_kafka_toppar_op_serve+0x583
[pc=0x00007fec74b99020, sp=0x00007fec3cbf8da0] in pthread_condattr_setpshared+0x340

---[ V8 JavaScript Stacktraces ]---
[pc=0x00007fec74c18ac0, sp=0x00007fec3cbf8e40] in __clone+0x40
```

Second case:
```
=========== Caught a Segmentation Fault [pid=1] ===========
-----[ Native Stacktraces ]-----
[pc=0x00007fa8580b468e, sp=0x00007fa30b5fcd60] in segfault_handler(int)+0x4e
[pc=0x00007fa85c58b050, sp=0x00007fa30b5fcd80] in __sigaction+0x40
[pc=0x00007fa859271c90, sp=0x00007fa30b5fda78] in NodeKafka::QueueCallbacks::QueueDispatcher::Execute()+0x0
[pc=0x00007fa85906d7e6, sp=0x00007fa30b5fda80] in rd_kafka_q_enq1.constprop.0.isra.0+0x166
[pc=0x00007fa859074064, sp=0x00007fa30b5fdab0] in rd_kafka_toppar_fetch_stop+0x44
[pc=0x00007fa859075e83, sp=0x00007fa30b5fdae0] in rd_kafka_toppar_op_serve+0x583
[pc=0x00007fa85901f7a4, sp=0x00007fa30b5fdb30] in rd_kafka_q_serve.localalias+0x324
[pc=0x00007fa858feeb0d, sp=0x00007fa30b5fdc60] in rd_kafka_thread_main+0x1fd
[pc=0x00007fa85c657ac0, sp=0x00007fa30b5fde40] in __clone+0x40
[pc=0x00007fa85c5d8020, sp=0x00007fa30b5fdda0] in pthread_condattr_setpshared+0x340
---[ V8 JavaScript Stacktraces ]---
```

The stack trace points to [QueueDispatcher::Execute](https://github.com/withthegrid/node-rdkafka/blob/segfault-fix/src/queue-callback.cc#L66). 

In `QueueDispatcher::Execute`, the issue could have been that `async` was true, then was accessed by some other thread and then `uv_async_send(async);` would have caused an error. I think this only could have been the `QueueDispatcher::Deactivate`. chatgpt suggested adding a lock (which can be seen in this PR). It gave another suggestion for `uv_close` in `QueueDispatcher::Deactivate` which I've also applied. 

Another issue which chatgpt talks about is the thread safety of `queue_event_callbacks`, which kind of results in just locking everything when working on it, but that hardly seems like a good solution. I think it would help to talk this through with jeroen or steven.

