### PR TITLE
fix: stop external thread callback before deleting opaque

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-rdkafka-imhoff",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-rdkafka-imhoff",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rdkafka-imhoff",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "2.5.3",
   "main": "lib/index.js",

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -410,12 +410,15 @@ Baton KafkaConsumer::ConfigureQueueNotEmptyCallback(RdKafka::TopicPartition * to
     this->queue_dispatcher_opaques[key] = opaque;
     rd_kafka_queue_cb_event_enable(rkqu, foreign_thread_queue_event_cb, (void *) opaque);
   } else if (hadCallbacks && !hasCallbacks){
+    // first make sure the other thread won't use the callback anymore.
+    rd_kafka_queue_cb_event_enable(rkqu, NULL, NULL);
+
+    // then delete the opaque dispatcher
     std::map<std::string, QueueCallbacks::QueueEventCallbackOpaque *>::iterator it = this->queue_dispatcher_opaques.find(key);
     if (it != this->queue_dispatcher_opaques.end()) {
       delete it->second;
       this->queue_dispatcher_opaques.erase(key);
     }
-    rd_kafka_queue_cb_event_enable(rkqu, NULL, NULL);
   }
   rd_kafka_queue_destroy(rkqu);
 

--- a/src/queue-callback.cc
+++ b/src/queue-callback.cc
@@ -15,14 +15,12 @@ namespace NodeKafka {
 namespace QueueCallbacks {
 
 QueueDispatcher::QueueDispatcher() {
-  printf("QueueDispatcher is being constructed \n");
   async = NULL;
   uv_mutex_init(&async_lock);
   uv_mutex_init(&event_lock);
 }
 
 QueueDispatcher::~QueueDispatcher() {
-  printf("QueueDispatcher is being destructed \n");
   if (queue_event_callbacks.size() < 1) return;
 
   std::map<std::string, std::vector<v8::Persistent<v8::Function, v8::CopyablePersistentTraits<v8::Function> > >>::iterator it;


### PR DESCRIPTION
I've done a test locally in which I remove the line with `rd_kafka_queue_cb_event_enable` and then stop and start a callback based consumer (by disconnecting a device or opening/closing the debugger in de console). This will trigger a segfault on stop. However this segfault also happens in the device-gateway, which is something that doesn't happen in production.

I can't compare the stack trace because I'm getting `Cannot unwind stacktraces: Feature disabled / Missing libunwind on your system` again, which is weird, because used the steps in: https://github.com/withthegrid/teleport/issues/2359.

Anyway, I think this change is still worth a try.

I've removed logging, because its not helping anymore.